### PR TITLE
Removed useElectronNet from got

### DIFF
--- a/packages/net/index.ts
+++ b/packages/net/index.ts
@@ -5,7 +5,7 @@ import { IncomingMessage } from "http";
 import { basename, resolve as pathResolve } from "path";
 import { fileURLToPath, parse } from "url";
 
-const IS_ELECTRON = process.versions.hasOwnProperty("electron");
+const IS_ELECTRON = false; // process.versions.hasOwnProperty("electron");
 
 export interface UpdatedObject {
     timestamp: string;


### PR DESCRIPTION
Fixed issue with electron 6.0.9 causing a lot of errors:
```
events.js:303 Uncaught TypeError: this.on is not a function
    at once (events.js:303)
    at CallbacksRegistry.apply (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\callbacks-registry.js:41)
    at D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:281
    at EventEmitter.<anonymous> (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:271)
    at EventEmitter.emit (events.js:200)
    at Object.onMessage (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\init.js:42)
once @ events.js:303
apply @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\callbacks-registry.js:41
(anonymous) @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:281
(anonymous) @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:271
emit @ events.js:200
onMessage @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\init.js:42
events.js:303 Uncaught TypeError: this.on is not a function
    at once (events.js:303)
    at CallbacksRegistry.apply (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\callbacks-registry.js:41)
    at D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:281
    at EventEmitter.<anonymous> (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:271)
    at EventEmitter.emit (events.js:200)
    at Object.onMessage (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\init.js:42)
once @ events.js:303
apply @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\callbacks-registry.js:41
(anonymous) @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:281
(anonymous) @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:271
emit @ events.js:200
onMessage @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\init.js:42
_stream_writable.js:278 Uncaught TypeError: Cannot read property 'objectMode' of undefined
    at Writable.write (_stream_writable.js:278)
    at CallbacksRegistry.apply (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\callbacks-registry.js:41)
    at D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:281
    at EventEmitter.<anonymous> (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:271)
    at EventEmitter.emit (events.js:200)
    at Object.onMessage (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\init.js:42)
Writable.write @ _stream_writable.js:278
apply @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\callbacks-registry.js:41
(anonymous) @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:281
(anonymous) @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:271
emit @ events.js:200
onMessage @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\init.js:42
_stream_writable.js:585 Uncaught TypeError: Cannot read property 'corked' of undefined
    at Writable.end (_stream_writable.js:585)
    at CallbacksRegistry.apply (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\callbacks-registry.js:41)
    at D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:281
    at EventEmitter.<anonymous> (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:271)
    at EventEmitter.emit (events.js:200)
    at Object.onMessage (D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\init.js:42)
Writable.end @ _stream_writable.js:585
apply @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\callbacks-registry.js:41
(anonymous) @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:281
(anonymous) @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\api\remote.js:271
emit @ events.js:200
onMessage @ D:\Users\lukew\Visual Studio\Minecraft-Box-Launcher\node_modules\electron\dist\resources\electron.asar\renderer\init.js:42

```