### PR TITLE
Fix inverted HTTP 304 (Not Modified) check in net/getIfUpdate

### DIFF
--- a/packages/net/index.ts
+++ b/packages/net/index.ts
@@ -32,7 +32,7 @@ export async function getIfUpdate<T extends UpdatedObject = UpdatedObject>(url: 
             encoding: "utf-8",
             headers: lastModified ? { "If-Modified-Since": lastModified } : undefined,
         });
-        if (resp.statusCode !== 304) {
+        if (resp.statusCode === 304) {
             return lastObj;
         }
         return {


### PR DESCRIPTION
The logic of this if statement was inverted in 4e4de129. This reverted that inversion.