### PR TITLE
fix: the file argument must be of type string

### DIFF
--- a/packages/launch/index.ts
+++ b/packages/launch/index.ts
@@ -230,7 +230,11 @@ export namespace Launcher {
         await (options.ensureNatives || ensureNative)(minecraftFolder, version, options.nativeRoot || minecraftFolder.getNativesRoot(version.id));
 
         const spawnOption = { cwd: options.gamePath, env: process.env, ...(options.extraExecOption || {}) };
-
+        
+        // change args[0] to java executable
+        args[0] = options.javaPath;
+        
+        // spawn minecraft
         return spawn(args[0], args.slice(1), spawnOption);
     }
 


### PR DESCRIPTION
When I run Launcher.launch(), I get the following error: The "file" argument must be of type string. Received type object. If I make the changes, there is no more error. However, I am not sure if this is the way to fix it.