### PR TITLE
fix: typescript definitions missing from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,5 @@
 tslint.json
 yggdrasil-mock-server-0.0.1-SNAPSHOT.jar
 /application.yaml
+
+!packages/**/*.d.ts


### PR DESCRIPTION
I get an error saying that type definitions are missing. I also noticed that the .ts files are missing too.

**Edit:**
Actually, I don't think this is the solution so don't merge it yet.