### PR TITLE
Add more robust check to Java installer

### DIFF
--- a/packages/installer/java.ts
+++ b/packages/installer/java.ts
@@ -67,8 +67,8 @@ export function installJreFromMojangTask(options: Options) {
         }
         const currentArch = resolveArch();
 
-        if (system === "unknown" || system === "linux") {
-            return;
+        if (!info[system] || !info[system][currentArch] || !info[system][currentArch].jre) {
+            throw new Error("No Java package available for your platform")
         }
         const { sha1, url } = info[system][currentArch].jre;
         const filename = basename(url);


### PR DESCRIPTION
Two lines, couple of major issues in my opinon:

- Trying to install Java on an unsupported platform should fail with an error, not quietly succeed. I spent an inordinate amount of time trying to figure out why the Java installer reported success but didn't actually do anything on my system.

- Not all platforms have both 32- and 64-bit downloads available, and those that do may change in the future.
