### PR TITLE
eslint changes to fix failing tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
     "tsconfigRootDir": "."
   },
   "plugins": [
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "import"
   ],
   "rules": {
     "@typescript-eslint/no-floating-promises": "error",
@@ -40,7 +41,7 @@
         ]
       }
     ],
-    "no-duplicate-imports": "error",
+    "import/no-duplicates": "error",
     "no-irregular-whitespace": "error",
     "no-mixed-spaces-and-tabs": "error",
     "no-trailing-spaces": "error",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@typescript-eslint/eslint-plugin": "^4.8.1",
         "@typescript-eslint/parser": "^4.8.1",
         "eslint": "^7.13.0",
+        "eslint-plugin-import": "^2.26.0",
         "jest": "^26.6.3",
         "rollup": "^2.33.3",
         "tslib": "^2.3.1",

--- a/packages/installer/forge.ts
+++ b/packages/installer/forge.ts
@@ -199,7 +199,7 @@ function extractEntryTo(zip: ZipFile, e: Entry, dest: string) {
 }
 
 async function installLegacyForgeFromZip(zip: ZipFile, entries: ForgeLegacyInstallerEntriesPattern, profile: InstallProfile, mc: MinecraftFolder, options: InstallForgeOptions) {
-    const versionJson = profile.versionInfo!;
+    const versionJson = profile.versionInfo;
 
     // apply override for inheritsFrom
     versionJson.id = options.versionId || versionJson.id;

--- a/packages/installer/install.e2e.test.ts
+++ b/packages/installer/install.e2e.test.ts
@@ -137,7 +137,7 @@ describe("ForgeInstaller", () => {
         const resolvedVersion = await Version.parse(tempDir, result);
         // https://github.com/Voxelum/minecraft-launcher-core-node/issues/210
         resolvedVersion.libraries.filter((lib) => lib.groupId === "org.scala-lang.plugins")
-            .forEach((lib) => { (lib.download as any).sha1 = "" });
+            .forEach((lib) => { (lib.download ).sha1 = "" });
         await installDependencies(resolvedVersion);
     });
     test("should install forge 1.12.2-14.23.5.2852", async () => {
@@ -206,7 +206,7 @@ describe("LiteloaderInstaller", () => {
             const resolvedVersion = await Version.parse(tempDir, result);
             // https://github.com/Voxelum/minecraft-launcher-core-node/issues/210
             resolvedVersion.libraries.filter((lib) => lib.groupId === "org.scala-lang.plugins")
-                .forEach((lib) => { (lib.download as any).sha1 = "" });
+                .forEach((lib) => { (lib.download ).sha1 = "" });
             await installDependencies(resolvedVersion);
         });
     });

--- a/packages/installer/profile.ts
+++ b/packages/installer/profile.ts
@@ -5,7 +5,7 @@ import type { ChildProcess } from "child_process";
 import { spawn } from "child_process";
 import { delimiter, dirname } from "path";
 import { ZipFile } from "yauzl";
-import { withAgents } from './http/agents';
+import { withAgents } from "./http/agents";
 import { InstallLibraryTask, InstallSideOption, LibraryOptions } from "./minecraft";
 import { checksum, errorToString, readFile, SpawnJavaOptions, spawnProcess, waitProcess } from "./utils";
 

--- a/packages/world/index.ts
+++ b/packages/world/index.ts
@@ -170,7 +170,7 @@ export class WorldReader {
 
     public async getAdvancementsData(): Promise<AdvancementDataFrame[]> {
         const files = await this.fs.listFiles("advancements");
-        return Promise.all(files.filter(f => f.endsWith('.dat'))
+        return Promise.all(files.filter((f) => f.endsWith(".dat"))
             .map((f) => this.fs.readFile(this.fs.join("advancements", f)).then((b) => deserialize<AdvancementDataFrame>(b))));
     }
 }


### PR DESCRIPTION
Changed eslint rule from `no-duplicate-imports` to `import/no-duplicates` and added in the `import` plugin required following advice mentioned here: https://github.com/typescript-eslint/typescript-eslint/issues/2315

eslint with `--fix` has then been run to fix all code issues and pass tests