### PR TITLE
@xmcl/resourcepack - New features (including a "minor" breaking change)

### DIFF
--- a/packages/resourcepack/modelLoader.ts
+++ b/packages/resourcepack/modelLoader.ts
@@ -37,6 +37,12 @@ export class ModelLoader {
         const path = ResourceLocation.deconstruct(modelPath, folder);
         const resourceLocation = ResourceLocation.ofModelPath(path);
 
+        const cacheName = resourceLocation.toString();
+
+        if(this.models[cacheName] != undefined){
+            return this.models[cacheName];   
+        }
+
         const resource = await this.loader.get(resourceLocation);
         if (!resource) { throw new Error(`Model ${modelPath} (${resourceLocation}) not found`); }
         const baseModel = JSON.parse(await resource.read("utf-8")) as BlockModel;
@@ -60,7 +66,6 @@ export class ModelLoader {
         delete baseModel.parent;
 
         const model: BlockModel.Resolved = baseModel as any;
-        this.models[modelPath] = model;
 
         const reg = this.textures;
         for (const variant of Object.keys(model.textures)) {
@@ -72,6 +77,8 @@ export class ModelLoader {
                 }
             }
         }
+
+        this.models[cacheName] = model;
         return model;
     }
 }

--- a/packages/resourcepack/resourcePack.ts
+++ b/packages/resourcepack/resourcePack.ts
@@ -15,48 +15,67 @@ import { PackMeta } from "./format";
  * The Minecraft used object to map the game resource location.
  */
 export class ResourceLocation {
+    static deconstruct(path:string, appendPath:string="") {
+        const splitPath = path.split(":");
+
+        const domain = (splitPath.length > 1 && splitPath[0]) ? splitPath[0] : "minecraft";
+        let resourcePath = splitPath.length > 1 ? splitPath[1] : splitPath[0];
+
+        if(appendPath.length > 0){
+            if(appendPath.charAt(appendPath.length - 1) != "/"){
+                appendPath = appendPath + "/";   
+            }
+            if (!resourcePath.startsWith(appendPath)) {
+                resourcePath = appendPath + resourcePath;
+            }
+        }
+
+        return new ResourceLocation(domain, resourcePath);
+    }
+    
     /**
      * build from texture path
      */
-    static ofTexturePath(path: string) {
-        const idx = path.indexOf(":");
-        if (idx === -1) { return new ResourceLocation("minecraft", `textures/${path}.png`); }
-        if (idx === 0) { return new ResourceLocation("minecraft", `textures/${path.substring(1, path.length)}.png`); }
-        return new ResourceLocation(path.substring(0, idx), `textures/${path.substring(idx + 1, path.length)}.png`);
-    }
-
-    static ofBlockModelPath(path: string) {
-        const splited = path.split(":");
-        const domain = (splited.length > 1 && splited[0]) ? splited[0] : "minecraft";
-        let blockPath = splited.length > 1 ? splited[1] : splited[0];
-        if (!blockPath.startsWith("block/")) {
-            // 1.12
-            blockPath = `block/${blockPath}`
-        }
-        return new ResourceLocation(domain, `models/${blockPath}.json`);
+    static ofTexturePath(location: string|ResourceLocation) {
+        if(typeof location == "string"){ location = ResourceLocation.deconstruct(location) };
+        return new ResourceLocation(location.domain, `textures/${location.path}.png`);
     }
 
     /**
      * build from model path
      */
-    static ofModelPath(path: string) {
-        const idx = path.indexOf(":");
-        if (idx === -1) { return new ResourceLocation("minecraft", `models/${path}.json`); }
-        if (idx === 0) { return new ResourceLocation("minecraft", `models/${path.substring(1, path.length)}.json`); }
-        return new ResourceLocation(path.substring(0, idx), `models/${path.substring(idx + 1, path.length)}.json`);
+    static ofBlockModelPath(location: string|ResourceLocation) {
+        location = ResourceLocation.deconstruct(location.toString(), "block/");
+        return new ResourceLocation(location.domain, `models/${location.path}.json`);
+    }
+
+    static ofItemModelPath(location: string|ResourceLocation) {
+        location = ResourceLocation.deconstruct(location.toString(), "item/");
+        return new ResourceLocation(location.domain, `models/${location.path}.json`);
+    }
+
+    static ofModelPath(location: string|ResourceLocation) {
+        if(typeof location == "string"){ location = ResourceLocation.deconstruct(location) };
+        return new ResourceLocation(location.domain, `models/${location.path}.json`);
+    }
+
+    /**
+     * build from block state path
+     */
+    static ofBlockStatePath(location: string|ResourceLocation) {
+        if(typeof location == "string"){ location = ResourceLocation.deconstruct(location) };
+        return new ResourceLocation(location.domain, `blockstates/${location.path}.json`);
     }
 
     /**
      * from absoluted path
      */
-    static fromPath(path: string) {
-        const idx = path.indexOf(":");
-        if (idx === -1) { return new ResourceLocation("minecraft", path); }
-        if (idx === 0) { return new ResourceLocation("minecraft", path.substring(1, path.length)); }
-        return new ResourceLocation(path.substring(0, idx), path.substring(idx + 1, path.length));
+    static fromPath(location: string|ResourceLocation) {
+        return ResourceLocation.deconstruct(location.toString());
     }
 
-    static getAssetsPath(location: ResourceLocation) {
+    static getAssetsPath(location: string|ResourceLocation) {
+        if(typeof location == "string"){ location = ResourceLocation.deconstruct(location) };
         return `assets/${location.domain}/${location.path}`;
     }
 


### PR DESCRIPTION
I've done this as 3 independent commits which, in chronological order, do the following:

**Commit 1:**

> Restructured `resourcePack.ts`'s `ResourceLocation` class to have more outputs as follows:
> - Addition of `ofItemModelPath` and `ofBlockStatePath` functions that were missing
> - Change to all `of...` functions to use a standardized function (`deconstruct`) instead of repeated code
> - Change to all `of...` functions inputs to both accept `string` and `ResourceLocation` types (Non-breaking change)

**Commit 2:**

> Reworked `modelLoader.ts`'s `new ModelLoader().loadModel` to:
> - Additional argument: `folder`
>   - defaults to `blocks` to make this a non-breaking change (mimics existing functionality)
>   - allows you to instead use `items` for item models (for example shown in item frames)
> - Change to variable names to be clearer (`parentModel` and `baseModel`)

**Commit 3:**

> - **❗[Breaking change]** Rework to the cache (`.models`) to instead use `resourceLocation.toString()` (instead of `modelPath`)
>   - This makes more sense, as different `modelPath` inputs could resolve to the same model, but  `resourceLocation.toString()` is unique
>   - I can find no references to the cache within the code, so this shouldn't break anything within the library
>   - Moved the point where items are added to the cache to after the textures are loaded to prevent any potential issues
> - Where a `.models` cache item is present it is now returned instead of re-loading the resource