### PR TITLE
Fix a resource leak in the @xmcl/mod-parser package

### DIFF
--- a/packages/mod-parser/fabric.ts
+++ b/packages/mod-parser/fabric.ts
@@ -193,5 +193,6 @@ export interface FabricModMetadata {
 export async function readFabricMod(file: FileSystem | string | Uint8Array): Promise<FabricModMetadata> {
     const fs = await resolveFileSystem(file);
     const content = await fs.readFile("fabric.mod.json", "utf-8");
+    fs.close();
     return JSON.parse(content.replace(/^\uFEFF/g, "").replace(/\n/g, ""));
 }

--- a/packages/mod-parser/forge.ts
+++ b/packages/mod-parser/forge.ts
@@ -708,6 +708,7 @@ export async function readForgeMod(mod: ForgeModInput): Promise<ForgeModMetadata
         modsToml: tomls,
         ...base,
     };
+    fs.close();
     return result;
 }
 

--- a/packages/mod-parser/liteloader.ts
+++ b/packages/mod-parser/liteloader.ts
@@ -31,5 +31,6 @@ export async function readLiteloaderMod(mod: string | Uint8Array | FileSystem) {
     if (!metadata.version) {
         (metadata as any).version = `${metadata.mcversion}:${metadata.revision || 0}`;
     }
+    fs.close();
     return metadata;
 }

--- a/packages/mod-parser/quilt.ts
+++ b/packages/mod-parser/quilt.ts
@@ -265,6 +265,7 @@ export interface QuiltLoaderData {
 export async function readQuiltMod(file: FileSystem | string | Uint8Array): Promise<QuiltModMetadata> {
     const fs = await resolveFileSystem(file);
     const content = await fs.readFile("quilt.mod.json", "utf-8");
+    fs.close();
     return JSON.parse(content.replace(/^\uFEFF/g, "").replace(/\n/g, ""));
 }
 


### PR DESCRIPTION
I noticed that running the following script caused an error when deleting the test folder in Windows file explorer because the stream was not closed:

const { readFabricMod } = require('@xmcl/mod-parser');

(async () => {
  await readFabricMod('./test/test.jar');

  // keep the program alive
  setInterval(() => { }, 1000);
})();

The fix should prevent the error from occurring.