### PR TITLE
Fix: Removing quotes for prependCommand

### DIFF
--- a/packages/core/launch.ts
+++ b/packages/core/launch.ts
@@ -791,7 +791,7 @@ export async function generateArguments(options: LaunchOption) {
   }
 
   if (options.prependCommand && options.prependCommand.trim().length > 0) {
-    cmd.unshift(options.prependCommand.trim())
+    cmd.unshift(...options.prependCommand.trim().split(' '))
   }
 
   return cmd


### PR DESCRIPTION
Fixed bug with https://github.com/Voxelum/x-minecraft-launcher/issues/857