### PR TITLE
fix: add explicit parameter types to FetchLike fallback functions

### DIFF
--- a/packages/curseforge/index.ts
+++ b/packages/curseforge/index.ts
@@ -525,8 +525,10 @@ export interface CurseforgeClientOptions {
   /**
    * The fetch function to use. The default is `fetch`
    */
-  fetch?: typeof fetch
+  fetch?: FetchLike
 }
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 export interface FingerprintMatch {
   /**
@@ -576,7 +578,7 @@ export class CurseforgeApiError extends Error {
  */
 export class CurseforgeV1Client {
   headers: Record<string, string>
-  private fetch: typeof fetch
+  private fetch: FetchLike
   private baseUrl: string
 
   constructor(
@@ -588,7 +590,7 @@ export class CurseforgeV1Client {
       ...options?.headers,
     }
     this.baseUrl = options?.baseUrl || 'https://api.curseforge.com'
-    this.fetch = options?.fetch || (((...args) => fetch(...args)) as typeof fetch)
+    this.fetch = options?.fetch ?? ((input: RequestInfo | URL, init?: RequestInit) => fetch(input, init))
   }
 
   /**

--- a/packages/file-transfer/download.ts
+++ b/packages/file-transfer/download.ts
@@ -115,7 +115,7 @@ export async function download(options: DownloadOptions): Promise<void> {
 
   const fd = await openFd(options.pendingFile || options.destination)
   signal?.throwIfAborted()
-  const errors = []
+  const errors: unknown[] = []
 
   try {
     for (const url of urls) {

--- a/packages/modrinth/index.ts
+++ b/packages/modrinth/index.ts
@@ -185,21 +185,23 @@ export interface ModrinthClientOptions {
   /**
    * The fetch function to use
    */
-  fetch?: typeof fetch
+  fetch?: FetchLike
 }
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 /**
  * @see https://docs.modrinth.com/api-spec
  */
 export class ModrinthV2Client {
   private baseUrl: string
-  private fetch: typeof fetch
+  private fetch: FetchLike
   headers: Record<string, string>
 
   constructor(options?: ModrinthClientOptions) {
     this.baseUrl = options?.baseUrl ?? 'https://api.modrinth.com'
     this.headers = options?.headers || {}
-    this.fetch = options?.fetch || (((...args) => fetch(...args)) as typeof fetch)
+    this.fetch = options?.fetch ?? ((input: RequestInfo | URL, init?: RequestInit) => fetch(input, init))
   }
 
   /**


### PR DESCRIPTION
Add explicit type annotations to fetch wrapper lambdas in curseforge and modrinth clients to satisfy TypeScript's spread argument checking.